### PR TITLE
[GG-41387] Update codeowners for Tango

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# the following github users/groups will be added to PR as reviewers automatically
+# see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+*       @getgoing/zulu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # the following github users/groups will be added to PR as reviewers automatically
 # see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*       @getgoing/zulu
+*       @getgoing/tango


### PR DESCRIPTION
## Reason

We need to update the CODEOWNERS configuration for the Tango team due to the reorganization

## Solution

anosql directories should be under sierra ownership from now on

## What was done in this PR

- CODEOWNERS file was updated

## Test plan

No testing required

---

**Ticket(s)**: GG-41387
